### PR TITLE
feat: add webhook trigger for CI pipeline, add git trigger for invent…

### DIFF
--- a/cra-config.yaml
+++ b/cra-config.yaml
@@ -18,3 +18,4 @@ CRA_TARGETS:
       TF_VAR_watson_machine_learning_instance_crn: "crn:v1:bluemix:public:pm-20:us-south:a/2e92ee435f984c5dbf970577b2ceec1f:6966b4da-de4c-4dfb-a1d2-8a635f7eeeae::"
       TF_VAR_watson_machine_learning_instance_guid: "4e621b22-5802-4013-896a-777fc345f424"
       TF_VAR_watson_machine_learning_instance_resource_name: "test-machine-learning-instance"
+      TF_VAR_inventory_repo_url: "https://us-south.git.cloud.ibm.com/yada.yada/04181-inventory-repo.git"

--- a/solutions/banking/main.tf
+++ b/solutions/banking/main.tf
@@ -236,6 +236,7 @@ resource "ibm_cd_tekton_pipeline_trigger" "ci_pipeline_webhook" {
 
 # Create git trigger for CD pipeline - to run inventory promotion once CI pipeline is complete
 resource "ibm_cd_tekton_pipeline_trigger" "cd_pipeline_inventory_promotion_trigger" {
+  count          = var.inventory_repo_url != null ? 1 : 0
   type           = "scm"
   pipeline_id    = var.cd_pipeline_id
   name           = "git-inventory-promotion-trigger"

--- a/solutions/banking/variables.tf
+++ b/solutions/banking/variables.tf
@@ -50,6 +50,7 @@ variable "cd_pipeline_id" {
 variable "inventory_repo_url" {
   description = "URL of the inventory repository"
   type        = string
+  default     = null
 }
 
 variable "watson_assistant_instance_id" {

--- a/solutions/banking/variables.tf
+++ b/solutions/banking/variables.tf
@@ -47,6 +47,11 @@ variable "cd_pipeline_id" {
   type        = string
 }
 
+variable "inventory_repo_url" {
+  description = "URL of the inventory repository"
+  type        = string
+}
+
 variable "watson_assistant_instance_id" {
   description = "ID of the WatsonX Assistant service instance"
   type        = string

--- a/solutions/banking/version.tf
+++ b/solutions/banking/version.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "hashicorp/null"
       version = ">= 3.2.1"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6.1"
+    }
     restapi = {
       source  = "Mastercard/restapi"
       version = ">= 1.19.1"

--- a/solutions/banking/watson-scripts/webhook-trigger.sh
+++ b/solutions/banking/watson-scripts/webhook-trigger.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+WEBHOOK_URL="$1"
+WEBHOOK_SECRET="$2"
+
+curl -X POST --header "Content-Type: application/json" --data "{\"webhook-token\":\"$WEBHOOK_SECRET\"}" "$WEBHOOK_URL"

--- a/tests/resources/existing-resources/main.tf
+++ b/tests/resources/existing-resources/main.tf
@@ -77,12 +77,6 @@ resource "ibm_cd_toolchain" "cd_toolchain_instance" {
   resource_group_id = module.resource_group.resource_group_id
 }
 
-resource "ibm_cd_toolchain" "cd_toolchain_instance" {
-  depends_on        = [ibm_resource_instance.cd_instance]
-  name              = "${var.prefix}-toolchain-instance"
-  resource_group_id = module.resource_group.resource_group_id
-}
-
 resource "ibm_cd_toolchain_tool_pipeline" "ci_toolchain_tool_pipeline_instance" {
   parameters {
     name = "${var.prefix}-pipeline-ci-01"

--- a/tests/resources/existing-resources/main.tf
+++ b/tests/resources/existing-resources/main.tf
@@ -77,6 +77,12 @@ resource "ibm_cd_toolchain" "cd_toolchain_instance" {
   resource_group_id = module.resource_group.resource_group_id
 }
 
+resource "ibm_cd_toolchain" "cd_toolchain_instance" {
+  depends_on        = [ibm_resource_instance.cd_instance]
+  name              = "${var.prefix}-toolchain-instance"
+  resource_group_id = module.resource_group.resource_group_id
+}
+
 resource "ibm_cd_toolchain_tool_pipeline" "ci_toolchain_tool_pipeline_instance" {
   parameters {
     name = "${var.prefix}-pipeline-ci-01"

--- a/tests/scripts/pre-validation.sh
+++ b/tests/scripts/pre-validation.sh
@@ -41,6 +41,7 @@ TF_VARS_FILE="terraform.tfvars"
   watson_machine_learning_instance_resource_name_var_name="watson_machine_learning_instance_resource_name"
   use_existing_resource_group_var_name="use_existing_resource_group"
   create_continuous_delivery_service_instance_var_name="create_continuous_delivery_service_instance"
+  inventory_repo_url_var_name="inventory_repo_url"
 
   resource_group_name_value=$(terraform output -state=terraform.tfstate -raw resource_group_name)
   toolchain_resource_group_value=$(terraform output -state=terraform.tfstate -raw resource_group_name)
@@ -53,6 +54,7 @@ TF_VARS_FILE="terraform.tfvars"
   watson_machine_learning_instance_resource_name_value=$(terraform output -state=terraform.tfstate -raw watson_machine_learning_instance_resource_name)
   use_existing_resource_group_value=true
   create_continuous_delivery_service_instance_value=false
+  inventory_repo_url_value="https://${REGION}.git.cloud.ibm.com/test-inventory-repo"
 
   echo "Appending required input variable values to ${JSON_FILE}.."
 
@@ -87,6 +89,8 @@ TF_VARS_FILE="terraform.tfvars"
         --arg use_existing_resource_group_value "${use_existing_resource_group_value}" \
         --arg create_continuous_delivery_service_instance_var_name "${create_continuous_delivery_service_instance_var_name}" \
         --arg create_continuous_delivery_service_instance_value "${create_continuous_delivery_service_instance_value}" \
+        --arg inventory_repo_url_var_name "${inventory_repo_url_var_name}" \
+        --arg inventory_repo_url_value "${inventory_repo_url_value}" \
         '. + {($prefix_var_name): $prefix_value,
           ($resource_group_name_var_name): $resource_group_name_value,
           ($toolchain_region_var_name): $toolchain_region_value,
@@ -101,7 +105,8 @@ TF_VARS_FILE="terraform.tfvars"
           ($watson_machine_learning_instance_guid_var_name): $watson_machine_learning_instance_guid_value,
           ($use_existing_resource_group_var_name): $use_existing_resource_group_value,
           ($create_continuous_delivery_service_instance_var_name): $create_continuous_delivery_service_instance_value,
-          ($watson_machine_learning_instance_resource_name_var_name): $watson_machine_learning_instance_resource_name_value}' "${JSON_FILE}" > tmpfile && mv tmpfile "${JSON_FILE}" || exit 1
+          ($watson_machine_learning_instance_resource_name_var_name): $watson_machine_learning_instance_resource_name_value,
+          ($inventory_repo_url_var_name): $inventory_repo_url_value}' "${JSON_FILE}" > tmpfile && mv tmpfile "${JSON_FILE}" || exit 1
 
   echo "Pre-validation complete successfully"
 )


### PR DESCRIPTION


### Description

- Add webhook for CI pipeline
- Trigger that webhook at end of DA run to start the CI pipeline
- Git trigger for inventory to promote build once CI completes
- Will require inventory_repo_url as new parameter - take this from the ALM DA

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
