### PR TITLE
make inventory repo null, so trigger will be skipped in test

### DIFF
--- a/tests/scripts/pre-validation.sh
+++ b/tests/scripts/pre-validation.sh
@@ -41,7 +41,6 @@ TF_VARS_FILE="terraform.tfvars"
   watson_machine_learning_instance_resource_name_var_name="watson_machine_learning_instance_resource_name"
   use_existing_resource_group_var_name="use_existing_resource_group"
   create_continuous_delivery_service_instance_var_name="create_continuous_delivery_service_instance"
-  inventory_repo_url_var_name="inventory_repo_url"
   secrets_manager_guid_var_name="secrets_manager_guid"
   secrets_manager_crn_var_name="secrets_manager_crn"
   signing_key_payload_var_name="signing_key_payload"
@@ -57,7 +56,6 @@ TF_VARS_FILE="terraform.tfvars"
   watson_machine_learning_instance_resource_name_value=$(terraform output -state=terraform.tfstate -raw watson_machine_learning_instance_resource_name)
   use_existing_resource_group_value=true
   create_continuous_delivery_service_instance_value=false
-  inventory_repo_url_value="https://${REGION}.git.cloud.ibm.com/test-inventory-repo"
   secrets_manager_guid_value=$(terraform output -state=terraform.tfstate -raw secrets_manager_guid)
   secrets_manager_crn_value=$(terraform output -state=terraform.tfstate -raw secrets_manager_crn)
   signing_key_payload_value=$(terraform output -state=terraform.tfstate -raw signing_key_payload)
@@ -95,8 +93,6 @@ TF_VARS_FILE="terraform.tfvars"
         --arg use_existing_resource_group_value "${use_existing_resource_group_value}" \
         --arg create_continuous_delivery_service_instance_var_name "${create_continuous_delivery_service_instance_var_name}" \
         --arg create_continuous_delivery_service_instance_value "${create_continuous_delivery_service_instance_value}" \
-        --arg inventory_repo_url_var_name "${inventory_repo_url_var_name}" \
-        --arg inventory_repo_url_value "${inventory_repo_url_value}" \
         --arg secrets_manager_crn_var_name "${secrets_manager_crn_var_name}" \
         --arg secrets_manager_crn_value "${secrets_manager_crn_value}" \
         --arg secrets_manager_guid_var_name "${secrets_manager_guid_var_name}" \
@@ -121,8 +117,7 @@ TF_VARS_FILE="terraform.tfvars"
           ($secrets_manager_secrets_manager_crn_var_name): $secrets_manager_crn_value,
           ($secrets_manager_guid_var_name): $secrets_manager_guid_value,
           ($signing_key_payload_var_name): $signing_key_payload_var_name,
-          ($signing_key_payload_value): signing_key_payload_value,
-          ($inventory_repo_url_var_name): $inventory_repo_url_value}' "${JSON_FILE}" > tmpfile && mv tmpfile "${JSON_FILE}" || exit 1
+          ($signing_key_payload_value): signing_key_payload_value' "${JSON_FILE}" > tmpfile && mv tmpfile "${JSON_FILE}" || exit 1
 
   echo "Pre-validation complete successfully"
 )

--- a/tests/scripts/pre-validation.sh
+++ b/tests/scripts/pre-validation.sh
@@ -54,7 +54,7 @@ TF_VARS_FILE="terraform.tfvars"
   watson_machine_learning_instance_resource_name_value=$(terraform output -state=terraform.tfstate -raw watson_machine_learning_instance_resource_name)
   use_existing_resource_group_value=true
   create_continuous_delivery_service_instance_value=false
-  inventory_repo_url_value="https://${REGION}.git.cloud.ibm.com/test-inventory-repo"
+  inventory_repo_url_value=""
 
   echo "Appending required input variable values to ${JSON_FILE}.."
 


### PR DESCRIPTION
### Description

remove requirement for inventory repo in testing, as we're not using it yet 

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
