### PR TITLE
fix: outputs and ci pipeline flag

### DIFF
--- a/solutions/banking/outputs.tf
+++ b/solutions/banking/outputs.tf
@@ -1,19 +1,19 @@
-output "project_id" {
+output "watsonx_project_id" {
   description = "ID of the created WatsonX project."
   value       = module.configure_project.project_id
 }
 
-output "project_url" {
+output "watsonx_project_url" {
   description = "WatsonX project ID URL."
   value       = "https://dataplatform.cloud.ibm.com/projects/${module.configure_project.project_id}"
 }
 
-output "watsonx_assistant_url" {
+output "watsonx_assistant_api_url" {
   description = "WatsonX Assistant URL."
   value       = local.watsonx_assistant_url
 }
 
-output "watsonx_discovery_url" {
+output "watsonx_discovery_api_url" {
   description = "WatsonX Discovery URL."
   value       = local.watsonx_discovery_url
 }
@@ -23,12 +23,12 @@ output "cos_instance_crn" {
   value       = module.cos.cos_instance_crn
 }
 
-output "assistant_integration_id" {
+output "watsonx_assistant_integration_id" {
   description = "WatsonX assistant integration ID."
   value       = data.external.assistant_get_integration_id.result.assistant_integration_id
 }
 
-output "discovery_project_id" {
+output "watsonx_discovery_project_id" {
   description = "WatsonX Discovery Project ID."
   value       = data.external.discovery_project_id.result.discovery_project_id
 }

--- a/tests/scripts/pre-validation.sh
+++ b/tests/scripts/pre-validation.sh
@@ -44,6 +44,7 @@ TF_VARS_FILE="terraform.tfvars"
   secrets_manager_guid_var_name="secrets_manager_guid"
   secrets_manager_region_var_name="secrets_manager_region"
   signing_key_var_name="signing_key"
+  trigger_ci_pipeline_run_var_name="trigger_ci_pipeline_run"
 
   resource_group_name_value=$(terraform output -state=terraform.tfstate -raw resource_group_name)
   toolchain_resource_group_value=$(terraform output -state=terraform.tfstate -raw resource_group_name)
@@ -58,6 +59,7 @@ TF_VARS_FILE="terraform.tfvars"
   create_continuous_delivery_service_instance_value=false
   secrets_manager_guid_value=$(terraform output -state=terraform.tfstate -raw secrets_manager_guid)
   signing_key_value=$(terraform output -state=terraform.tfstate -raw signing_key)
+  trigger_ci_pipeline_run_value=false
 
   echo "Appending required input variable values to ${JSON_FILE}.."
 
@@ -98,6 +100,8 @@ TF_VARS_FILE="terraform.tfvars"
         --arg secrets_manager_guid_value "${secrets_manager_guid_value}" \
         --arg signing_key_var_name "${signing_key_var_name}" \
         --arg signing_key_value "${signing_key_value}" \
+        --arg trigger_ci_pipeline_run_var_name "${trigger_ci_pipeline_run_var_name}" \
+        --arg trigger_ci_pipeline_run_value "${trigger_ci_pipeline_run_value}" \
         '. + {($prefix_var_name): $prefix_value,
           ($resource_group_name_var_name): $resource_group_name_value,
           ($toolchain_region_var_name): $toolchain_region_value,
@@ -115,6 +119,7 @@ TF_VARS_FILE="terraform.tfvars"
           ($watson_machine_learning_instance_resource_name_var_name): $watson_machine_learning_instance_resource_name_value,
           ($secrets_manager_guid_var_name): $secrets_manager_guid_value,
           ($secrets_manager_region_var_name): $secrets_manager_region_value,
+          ($trigger_ci_pipeline_run_var_name): $trigger_ci_pipeline_run_value,
           ($signing_key_var_name): $signing_key_value}' "${JSON_FILE}" > tmpfile && mv tmpfile "${JSON_FILE}" || exit 1
 
   echo "Pre-validation complete successfully"


### PR DESCRIPTION
### Description

- Rename outputs
- Fix CI pipeline run flag

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
