### PR TITLE
fix: add branch property to webhook trigger so app builds correctly

### DIFF
--- a/solutions/banking/main.tf
+++ b/solutions/banking/main.tf
@@ -267,6 +267,16 @@ resource "ibm_cd_tekton_pipeline_trigger" "ci_pipeline_webhook" {
   }
 }
 
+# Ensure webhook trigger runs against correct git branch
+resource "ibm_cd_tekton_pipeline_trigger_property" "ci_pipeline_webhook_branch_property" {
+  depends_on  = [ibm_cd_tekton_pipeline_trigger.ci_pipeline_webhook]
+  name        = "branch"
+  pipeline_id = var.ci_pipeline_id
+  trigger_id  = ibm_cd_tekton_pipeline_trigger.ci_pipeline_webhook.trigger_id
+  type        = "text"
+  value       = "main"
+}
+
 # Create git trigger for CD pipeline - to run inventory promotion once CI pipeline is complete
 resource "ibm_cd_tekton_pipeline_trigger" "cd_pipeline_inventory_promotion_trigger" {
   provider       = ibm.ibm_resources
@@ -290,6 +300,7 @@ resource "null_resource" "ci_pipeline_run" {
   count = var.trigger_ci_pipeline_run == true ? 1 : 0
   depends_on = [
     ibm_cd_tekton_pipeline_trigger.ci_pipeline_webhook,
+    ibm_cd_tekton_pipeline_trigger_property.ci_pipeline_webhook_branch_property,
     ibm_cd_tekton_pipeline_property.watsonx_assistant_integration_id_pipeline_property_ci,
     ibm_cd_tekton_pipeline_property.watsonx_assistant_id_pipeline_property_ci,
     ibm_resource_instance.cd_instance


### PR DESCRIPTION
### Description

- Added text property to webhook trigger to ensure the main branch gets built. From previous behaviour, it seems the pipeline tries to default to "master".

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
