### PR TITLE
feat: watsonx admin api key to sm secrets

### DIFF
--- a/solutions/banking/main.tf
+++ b/solutions/banking/main.tf
@@ -61,6 +61,23 @@ module "secrets_manager_secret_signing_key" {
   secret_payload_password = var.signing_key
 }
 
+# secrets manager secrets - WATSONX ADMIN API KEY
+module "secrets_manager_secret_watsonx_admin_api_key" {
+  providers = {
+    ibm = ibm.sm_resources
+  }
+  count                   = (var.create_secrets && var.watsonx_admin_api_key != null) ? 1 : 0
+  source                  = "terraform-ibm-modules/secrets-manager-secret/ibm"
+  version                 = "1.3.1"
+  region                  = var.secrets_manager_region
+  secrets_manager_guid    = var.secrets_manager_guid
+  secret_name             = "watsonx-admin-api-key"
+  secret_description      = "WatsonX Admin API Key"
+  secret_type             = "arbitrary" #checkov:skip=CKV_SECRET_6
+  secret_payload_password = var.watsonx_admin_api_key
+}
+
+
 data "ibm_resource_group" "toolchain_resource_group_id" {
   provider = ibm.ibm_resources
   name     = var.toolchain_resource_group


### PR DESCRIPTION
### Description

Adds watsonx_admin_api_key to SM secrets.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
