### PR TITLE
added prefix to discovery project and collection, fixed watson discovery variable names

### DIFF
--- a/solutions/banking/main.tf
+++ b/solutions/banking/main.tf
@@ -1,8 +1,8 @@
 locals {
   watsonx_assistant_url            = "https://api.${var.watson_assistant_region}.assistant.watson.cloud.ibm.com/instances/${var.watson_assistant_instance_id}"
   watson_discovery_url             = "//api.${var.watson_discovery_region}.discovery.watson.cloud.ibm.com/instances/${var.watson_discovery_instance_id}"
-  watson_discovery_project_name    = var.prefix != "" ? "${var.prefix}-gen-ai-rag-sample-app-project" : "gen-ai-rag-sample-app-project"
-  watson_discovery_collection_name = var.prefix != "" ? "${var.prefix}-gen-ai-rag-sample-app-data" : "gen-ai-rag-sample-app-data"
+  watson_discovery_project_name    = var.prefix != null ? "${var.prefix}-gen-ai-rag-sample-app-project" : "gen-ai-rag-sample-app-project"
+  watson_discovery_collection_name = var.prefix != null ? "${var.prefix}-gen-ai-rag-sample-app-data" : "gen-ai-rag-sample-app-data"
   sensitive_tokendata              = sensitive(data.ibm_iam_auth_token.tokendata.iam_access_token)
 }
 

--- a/solutions/banking/main.tf
+++ b/solutions/banking/main.tf
@@ -1,7 +1,9 @@
 locals {
-  watsonx_assistant_url = "https://api.${var.watson_assistant_region}.assistant.watson.cloud.ibm.com/instances/${var.watson_assistant_instance_id}"
-  watsonx_discovery_url = "//api.${var.watson_discovery_region}.discovery.watson.cloud.ibm.com/instances/${var.watson_discovery_instance_id}"
-  sensitive_tokendata   = sensitive(data.ibm_iam_auth_token.tokendata.iam_access_token)
+  watsonx_assistant_url            = "https://api.${var.watson_assistant_region}.assistant.watson.cloud.ibm.com/instances/${var.watson_assistant_instance_id}"
+  watson_discovery_url             = "//api.${var.watson_discovery_region}.discovery.watson.cloud.ibm.com/instances/${var.watson_discovery_instance_id}"
+  watson_discovery_project_name    = var.prefix != "" ? "${var.prefix}-gen-ai-rag-sample-app-project" : "gen-ai-rag-sample-app-project"
+  watson_discovery_collection_name = var.prefix != "" ? "${var.prefix}-gen-ai-rag-sample-app-data" : "gen-ai-rag-sample-app-data"
+  sensitive_tokendata              = sensitive(data.ibm_iam_auth_token.tokendata.iam_access_token)
 }
 
 data "ibm_iam_auth_token" "tokendata" {}
@@ -114,25 +116,25 @@ module "configure_project" {
 # Discovery project creation
 resource "restapi_object" "configure_discovery_project" {
   depends_on     = [data.ibm_iam_auth_token.tokendata]
-  path           = local.watsonx_discovery_url
-  read_path      = "${local.watsonx_discovery_url}/v2/projects/{id}?version=2023-03-31"
+  path           = local.watson_discovery_url
+  read_path      = "${local.watson_discovery_url}/v2/projects/{id}?version=2023-03-31"
   read_method    = "GET"
-  create_path    = "${local.watsonx_discovery_url}/v2/projects?version=2023-03-31"
+  create_path    = "${local.watson_discovery_url}/v2/projects?version=2023-03-31"
   create_method  = "POST"
   id_attribute   = "project_id"
   destroy_method = "DELETE"
-  destroy_path   = "${local.watsonx_discovery_url}/v2/projects/{id}?version=2023-03-31"
+  destroy_path   = "${local.watson_discovery_url}/v2/projects/{id}?version=2023-03-31"
   data           = <<-EOT
                   {
-                    "name": "gen-ai-rag-sample-app-project",
+                    "name": "${local.watson_discovery_project_name}",
                     "type": "document_retrieval"
                   }
                   EOT
   update_method  = "POST"
-  update_path    = "${local.watsonx_discovery_url}/v2/projects/{id}?version=2023-03-31"
+  update_path    = "${local.watson_discovery_url}/v2/projects/{id}?version=2023-03-31"
   update_data    = <<-EOT
                   {
-                    "name": "gen-ai-rag-sample-app-project",
+                    "name": "${local.watson_discovery_project_name}",
                     "type": "document_retrieval"
                   }
                   EOT
@@ -141,25 +143,25 @@ resource "restapi_object" "configure_discovery_project" {
 # Discovery collection creation
 resource "restapi_object" "configure_discovery_collection" {
   depends_on     = [data.ibm_iam_auth_token.tokendata, restapi_object.configure_discovery_project]
-  path           = local.watsonx_discovery_url
-  read_path      = "${local.watsonx_discovery_url}/v2/projects/${restapi_object.configure_discovery_project.id}/collections/{id}?version=2023-03-31"
+  path           = local.watson_discovery_url
+  read_path      = "${local.watson_discovery_url}/v2/projects/${restapi_object.configure_discovery_project.id}/collections/{id}?version=2023-03-31"
   read_method    = "GET"
-  create_path    = "${local.watsonx_discovery_url}/v2/projects/${restapi_object.configure_discovery_project.id}/collections?version=2023-03-31"
+  create_path    = "${local.watson_discovery_url}/v2/projects/${restapi_object.configure_discovery_project.id}/collections?version=2023-03-31"
   create_method  = "POST"
   id_attribute   = "collection_id"
   destroy_method = "DELETE"
-  destroy_path   = "${local.watsonx_discovery_url}/v2/projects/${restapi_object.configure_discovery_project.id}/collections/{id}?version=2023-03-31"
+  destroy_path   = "${local.watson_discovery_url}/v2/projects/${restapi_object.configure_discovery_project.id}/collections/{id}?version=2023-03-31"
   data           = <<-EOT
                   {
-                    "name": "gen-ai-rag-sample-app-data",
+                    "name": "${local.watson_discovery_collection_name}",
                     "description": "Sample data"
                   }
                   EOT
   update_method  = "POST"
-  update_path    = "${local.watsonx_discovery_url}/v2/projects/${restapi_object.configure_discovery_project.id}/collections/{id}?version=2023-03-31"
+  update_path    = "${local.watson_discovery_url}/v2/projects/${restapi_object.configure_discovery_project.id}/collections/{id}?version=2023-03-31"
   update_data    = <<-EOT
                   {
-                    "name": "gen-ai-rag-sample-app-data",
+                    "name": "${local.watson_discovery_collection_name}",
                     "description": "Sample data"
                   }
                   EOT
@@ -173,7 +175,7 @@ resource "null_resource" "discovery_file_upload" {
   }
 
   provisioner "local-exec" {
-    command     = "${path.module}/watson-scripts/discovery-file-upload.sh \"https:${local.watsonx_discovery_url}\" \"${restapi_object.configure_discovery_project.id}\" \"${restapi_object.configure_discovery_collection.id}\" \"${path.module}/artifacts/WatsonDiscovery\" "
+    command     = "${path.module}/watson-scripts/discovery-file-upload.sh \"https:${local.watson_discovery_url}\" \"${restapi_object.configure_discovery_project.id}\" \"${restapi_object.configure_discovery_collection.id}\" \"${path.module}/artifacts/WatsonDiscovery\" "
     interpreter = ["/bin/bash", "-c"]
     quiet       = true
     environment = {

--- a/solutions/banking/outputs.tf
+++ b/solutions/banking/outputs.tf
@@ -15,7 +15,7 @@ output "watsonx_assistant_api_url" {
 
 output "watson_discovery_api_url" {
   description = "Watson Discovery URL."
-  value       = "https:${local.watsonx_discovery_url}"
+  value       = "https:${local.watson_discovery_url}"
 }
 
 output "cos_instance_crn" {


### PR DESCRIPTION

### Description

- Added prefix to discovery project and collection names, if the prefix variable is specified
- Fixed discovery variable names from WatsonX to Watson
- Future PR will handle custom names for both Discovery and Assistant

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
