### PR TITLE
bug: Elastic index mapping config

### DIFF
--- a/modules/elastic-index/variables.tf
+++ b/modules/elastic-index/variables.tf
@@ -14,6 +14,12 @@ variable "elastic_index_name" {
   default     = "sample-rag-app-content"
 }
 
+variable "elastic_index_mapping" {
+  description = "Mapping configuration for the Elastic index"
+  type        = string
+  default     = "{}"
+}
+
 variable "elastic_index_entries_file" {
   description = "Path to JSON file with content entries"
   type        = string

--- a/solutions/banking/main.tf
+++ b/solutions/banking/main.tf
@@ -173,6 +173,7 @@ module "configure_elastic_index" {
   source                     = "../../modules/elastic-index"
   elastic_service_binding    = local.elastic_service_binding
   elastic_index_name         = local.elastic_index_name
+  elastic_index_mapping      = jsonencode(jsondecode(file("${path.module}/artifacts/watsonx.Assistant/elastic-search-skill.json")).search_settings.schema_mapping)
   elastic_index_entries_file = var.elastic_upload_sample_data ? "./artifacts/watsonx.Assistant/bank-loan-faqs.json" : null
   depends_on                 = [data.ibm_iam_auth_token.tokendata]
 }

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -170,7 +170,7 @@ func TestRunUpgradeExample(t *testing.T) {
 
 		options.IgnoreDestroys = testhelper.Exemptions{
 			List: []string{
-				"null_resource.discovery_file_upload",
+				"module.configure_discovery_project[0].null_resource.discovery_file_upload",
 			},
 		}
 


### PR DESCRIPTION
### Description

When an elastic search option is used with Watson Assistant, the latter updates the index mapping from the configuration provided to the assistant, but the elastic index resource did not have the same config, so on a subsequent apply, the mapping difference in index forces it to be recreated.
- Use attribute mapping from Assistant artifact to configure Elastic index mapping in the resource
- Redo index entries upload if index is recreated - previously the depends_on and name reference was not enough, added index ID as a parameter to shell_script resource
- Index entries delete operation now ignores an error if the index itself is deleted - this makes redeployments more robust.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [X] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
