### PR TITLE
feat: add storage delegation from SaaS DA for WatsonX project

### DIFF
--- a/modules/watson-machine-learning/main.tf
+++ b/modules/watson-machine-learning/main.tf
@@ -17,7 +17,7 @@ module "storage_delegation" {
     restapi.restapi_watsonx_admin = restapi.restapi_watsonx_admin
   }
   source               = "git::https://github.com/terraform-ibm-modules/terraform-ibm-watsonx-saas-da.git//storage_delegation?ref=v1.4.0"
-  count                = var.watsonx_project_delegated ? 0 : 1
+  count                = var.watsonx_project_delegated ? 1 : 0
   cos_kms_crn          = var.cos_kms_crn
   cos_kms_key_crn      = var.cos_kms_key_crn
   cos_kms_new_key_name = var.cos_kms_new_key_name

--- a/modules/watson-machine-learning/main.tf
+++ b/modules/watson-machine-learning/main.tf
@@ -10,6 +10,22 @@ module "cos" {
   cos_plan          = "standard"
 }
 
+module "storage_delegation" {
+  providers = {
+    ibm                           = ibm
+    ibm.deployer                  = ibm
+    restapi.restapi_watsonx_admin = restapi.restapi_watsonx_admin
+  }
+  source               = "github.com/terraform-ibm-modules/terraform-ibm-watsonx-saas-da.git//storage_delegation?ref=v1.4.0"
+  depends_on           = [module.cos]
+  count                = var.cos_kms_crn == null || var.cos_kms_crn == "" ? 0 : 1
+  cos_kms_crn          = var.cos_kms_crn
+  cos_kms_key_crn      = var.cos_kms_key_crn
+  cos_kms_new_key_name = var.cos_kms_new_key_name
+  cos_kms_ring_id      = var.cos_kms_ring_id
+  cos_guid             = module.cos.cos_instance_guid
+}
+
 ## Use code from Watson SaaS directly to avoid "legacy module" issues
 ## Note: passing a non-null delegated storage attribute may result in API errors
 

--- a/modules/watson-machine-learning/main.tf
+++ b/modules/watson-machine-learning/main.tf
@@ -16,9 +16,8 @@ module "storage_delegation" {
     ibm.deployer                  = ibm
     restapi.restapi_watsonx_admin = restapi.restapi_watsonx_admin
   }
-  source               = "github.com/terraform-ibm-modules/terraform-ibm-watsonx-saas-da.git//storage_delegation?ref=v1.4.0"
-  depends_on           = [module.cos]
-  count                = var.cos_kms_crn == null || var.cos_kms_crn == "" ? 0 : 1
+  source               = "git::https://github.com/terraform-ibm-modules/terraform-ibm-watsonx-saas-da.git//storage_delegation?ref=v1.4.0"
+  count                = var.watsonx_project_delegated ? 0 : 1
   cos_kms_crn          = var.cos_kms_crn
   cos_kms_key_crn      = var.cos_kms_key_crn
   cos_kms_new_key_name = var.cos_kms_new_key_name
@@ -29,8 +28,8 @@ module "storage_delegation" {
 ## Use code from Watson SaaS directly to avoid "legacy module" issues
 ## Note: passing a non-null delegated storage attribute may result in API errors
 
-
 resource "restapi_object" "configure_project" {
+  depends_on     = [module.storage_delegation]
   provider       = restapi.restapi_watsonx_admin
   path           = local.dataplatform_api
   read_path      = "${local.dataplatform_api}{id}"

--- a/modules/watson-machine-learning/variables.tf
+++ b/modules/watson-machine-learning/variables.tf
@@ -9,7 +9,7 @@ variable "cos_instance_name" {
 }
 
 variable "cos_kms_crn" {
-  description = "Key Protect service instance CRN used to encrypt the COS buckets used by the watsonx projects."
+  description = "KMS service instance CRN used to encrypt the COS buckets used by the watsonx projects."
   type        = string
   default     = null
 
@@ -23,19 +23,18 @@ variable "cos_kms_crn" {
 }
 
 variable "cos_kms_key_crn" {
-  description = "Key Protect key CRN used to encrypt the COS buckets used by the watsonx projects. If not set, then the cos_kms_new_key_name must be specified."
+  description = "KMS key CRN used to encrypt the COS buckets used by the watsonx projects. If not set, then the cos_kms_new_key_name must be specified."
   type        = string
   default     = null
 }
 
 variable "cos_kms_new_key_name" {
-  description = "Name of the Key Protect key to create for encrypting the COS buckets used by the watsonx projects."
+  description = "Name of the KMS key to create for encrypting the COS buckets used by the watsonx projects."
   type        = string
-  default     = ""
 }
 
 variable "cos_kms_ring_id" {
-  description = "The identifier of the Key Protect ring to create the cos_kms_new_key_name into. If it is not set, then the new key will be created in the default ring."
+  description = "The identifier of the KMS ring to create the cos_kms_new_key_name into. If it is not set, then the new key will be created in the default ring."
   type        = string
   default     = null
 }

--- a/modules/watson-machine-learning/variables.tf
+++ b/modules/watson-machine-learning/variables.tf
@@ -8,6 +8,38 @@ variable "cos_instance_name" {
   type        = string
 }
 
+variable "cos_kms_crn" {
+  description = "Key Protect service instance CRN used to encrypt the COS buckets used by the watsonx projects."
+  type        = string
+  default     = null
+
+  validation {
+    condition = anytrue([
+      can(regex("^crn:(.*:){3}kms:(.*:){2}[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}::$", var.cos_kms_crn)),
+      var.cos_kms_crn == null,
+    ])
+    error_message = "Key Protect CRN validation failed."
+  }
+}
+
+variable "cos_kms_key_crn" {
+  description = "Key Protect key CRN used to encrypt the COS buckets used by the watsonx projects. If not set, then the cos_kms_new_key_name must be specified."
+  type        = string
+  default     = null
+}
+
+variable "cos_kms_new_key_name" {
+  description = "Name of the Key Protect key to create for encrypting the COS buckets used by the watsonx projects."
+  type        = string
+  default     = ""
+}
+
+variable "cos_kms_ring_id" {
+  description = "The identifier of the Key Protect ring to create the cos_kms_new_key_name into. If it is not set, then the new key will be created in the default ring."
+  type        = string
+  default     = null
+}
+
 variable "watson_ml_instance_crn" {
   description = "Watson Machine Learning instance CRN"
   type        = string

--- a/solutions/banking/main.tf
+++ b/solutions/banking/main.tf
@@ -114,7 +114,7 @@ module "configure_wml_project" {
   }
   count                            = local.use_watson_machine_learning ? 1 : 0
   source                           = "../../modules/watson-machine-learning"
-  watsonx_project_delegated        = var.cos_kms_crn ? true : false
+  watsonx_project_delegated        = var.cos_kms_crn != null ? true : false
   watson_ml_instance_guid          = var.watson_machine_learning_instance_guid
   watson_ml_instance_crn           = var.watson_machine_learning_instance_crn
   watson_ml_instance_resource_name = var.watson_machine_learning_instance_resource_name

--- a/solutions/banking/main.tf
+++ b/solutions/banking/main.tf
@@ -114,6 +114,7 @@ module "configure_wml_project" {
   }
   count                            = local.use_watson_machine_learning ? 1 : 0
   source                           = "../../modules/watson-machine-learning"
+  watsonx_project_delegated        = var.cos_kms_crn ? true : false
   watson_ml_instance_guid          = var.watson_machine_learning_instance_guid
   watson_ml_instance_crn           = var.watson_machine_learning_instance_crn
   watson_ml_instance_resource_name = var.watson_machine_learning_instance_resource_name

--- a/solutions/banking/main.tf
+++ b/solutions/banking/main.tf
@@ -3,6 +3,8 @@ locals {
   use_watson_machine_learning = (var.watson_machine_learning_instance_guid != null) ? true : false
   use_elastic_index           = (var.elastic_instance_crn != null) ? true : false
 
+  cos_instance_name                = var.prefix != null ? "${var.prefix}-rag-sample-app-cos" : "gen-ai-rag-sample-app-cos"
+  cos_kms_new_key_name             = var.prefix != null ? "${var.prefix}-${var.cos_kms_new_key_name}" : var.cos_kms_new_key_name
   watsonx_assistant_url            = "//api.${var.watson_assistant_region}.assistant.watson.cloud.ibm.com/instances/${var.watson_assistant_instance_id}"
   watson_discovery_url             = local.use_watson_discovery ? "//api.${var.watson_discovery_region}.discovery.watson.cloud.ibm.com/instances/${var.watson_discovery_instance_id}" : null
   watson_discovery_project_name    = var.prefix != null ? "${var.prefix}-gen-ai-rag-sample-app-project" : "gen-ai-rag-sample-app-project"
@@ -106,6 +108,7 @@ resource "ibm_resource_instance" "cd_instance" {
 
 module "configure_wml_project" {
   providers = {
+    ibm                           = ibm.ibm_resources
     ibm.ibm_resources             = ibm.ibm_resources
     restapi.restapi_watsonx_admin = restapi.restapi_watsonx_admin
   }
@@ -116,8 +119,12 @@ module "configure_wml_project" {
   watson_ml_instance_resource_name = var.watson_machine_learning_instance_resource_name
   watson_ml_project_name           = local.watson_ml_project_name
   resource_group_id                = module.resource_group.resource_group_id
-  cos_instance_name                = "${var.prefix}-rag-sample-app-cos"
-  location                         = var.watson_discovery_region # WatsonX services needs to be in the same region anyway
+  cos_instance_name                = local.cos_instance_name
+  cos_kms_crn                      = var.cos_kms_crn
+  cos_kms_key_crn                  = var.cos_kms_key_crn
+  cos_kms_ring_id                  = var.cos_kms_ring_id
+  cos_kms_new_key_name             = local.cos_kms_new_key_name
+  location                         = var.watson_assistant_region
 }
 
 moved {

--- a/solutions/banking/variables.tf
+++ b/solutions/banking/variables.tf
@@ -100,6 +100,38 @@ variable "watson_machine_learning_instance_resource_name" {
   default     = null # WML usage is optional, elastic can be used instead
 }
 
+variable "cos_kms_crn" {
+  description = "Key Protect service instance CRN used to encrypt the COS buckets used by the watsonx projects."
+  type        = string
+  default     = null
+
+  validation {
+    condition = anytrue([
+      can(regex("^crn:(.*:){3}kms:(.*:){2}[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}::$", var.cos_kms_crn)),
+      var.cos_kms_crn == null,
+    ])
+    error_message = "Key Protect CRN validation failed."
+  }
+}
+
+variable "cos_kms_key_crn" {
+  description = "Key Protect key CRN used to encrypt the COS buckets used by the watsonx projects. If not set, then the cos_kms_new_key_name must be specified."
+  type        = string
+  default     = null
+}
+
+variable "cos_kms_new_key_name" {
+  description = "Name of the Key Protect key to create for encrypting the COS buckets used by the watsonx projects."
+  type        = string
+  default     = ""
+}
+
+variable "cos_kms_ring_id" {
+  description = "The identifier of the Key Protect ring to create the cos_kms_new_key_name into. If it is not set, then the new key will be created in the default ring."
+  type        = string
+  default     = null
+}
+
 variable "elastic_instance_crn" {
   description = "Elastic ICD instance CRN"
   type        = string


### PR DESCRIPTION
### Description

- Added storage delegation module from the SaaS DA, so that we can encrypt storage buckets with Key Protect

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
