### PR TITLE
Lock into provider version for DA

### DIFF
--- a/solutions/banking/version.tf
+++ b/solutions/banking/version.tf
@@ -1,4 +1,5 @@
 terraform {
+  # Lock DA into an exact provider version - renovate automation will keep it updated
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"

--- a/solutions/banking/version.tf
+++ b/solutions/banking/version.tf
@@ -2,31 +2,31 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.69.2"
+      version = "1.69.2"
     }
     null = {
       source  = "hashicorp/null"
-      version = ">= 3.2.3"
+      version = "3.2.3"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.6.3"
+      version = "3.6.3"
     }
     restapi = {
       source  = "Mastercard/restapi"
-      version = ">= 1.20.0"
+      version = "1.20.0"
     }
     shell = {
       source  = "scottwinkler/shell"
-      version = ">= 1.7.10"
+      version = "1.7.10"
     }
     elasticstack = {
       source  = "elastic/elasticstack"
-      version = ">= 0.11.7"
+      version = "0.11.7"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.32.0"
+      version = "2.32.0"
     }
   }
   required_version = ">= 1.3.0"


### PR DESCRIPTION
### Description

DAs should be locked into an exact provider version instead of using a range to ensure the same version is used in a specific version of a DA. By using `>=` it means the latest will always be pulled and something could break in a later version of a provider on a DA version that had been working fine.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
