### PR TITLE
fix: remove watsonx mark as sensitive var

### DIFF
--- a/solutions/banking/main.tf
+++ b/solutions/banking/main.tf
@@ -135,7 +135,6 @@ module "configure_wml_project" {
   watson_ml_instance_crn           = var.watson_machine_learning_instance_crn
   watson_ml_instance_resource_name = var.watson_machine_learning_instance_resource_name
   watson_ml_project_name           = local.watson_ml_project_name
-  watson_ml_project_sensitive      = var.watson_project_sensitive
   resource_group_id                = module.resource_group.resource_group_id
   cos_instance_name                = local.cos_instance_name
   cos_kms_crn                      = var.cos_kms_crn

--- a/solutions/banking/variables.tf
+++ b/solutions/banking/variables.tf
@@ -106,12 +106,6 @@ variable "watson_project_name" {
   default     = "RAG-sample-project"
 }
 
-variable "watson_project_sensitive" {
-  description = "Mark Watson project as sensitive"
-  type        = bool
-  default     = false
-}
-
 variable "cos_kms_crn" {
   description = "Key Protect service instance CRN used to encrypt the COS buckets used by the watsonx projects."
   type        = string


### PR DESCRIPTION
### Description

Mark as sensitive var was add to Watsonx DA so has been removed from this da.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
