### PR TITLE
fix: set `provider_visibility` back to public to workaround provider bug

### DIFF
--- a/solutions/banking/variables.tf
+++ b/solutions/banking/variables.tf
@@ -7,7 +7,7 @@ variable "provider_visibility" {
   description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
   type        = string
   # Defaulting this to public to workaround https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5828
-  default     = "public"
+  default = "public"
 
   validation {
     condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)

--- a/solutions/banking/variables.tf
+++ b/solutions/banking/variables.tf
@@ -6,7 +6,8 @@ variable "ibmcloud_api_key" {
 variable "provider_visibility" {
   description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
   type        = string
-  default     = "private"
+  # Defaulting this to public to workaround https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5828
+  default     = "public"
 
   validation {
     condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)


### PR DESCRIPTION
### Description

set `provider_visibility` back to public to workaround provider bug: https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5828

I also created an issue to plug the test gap which allowed the bug to get into the DA: https://github.com/terraform-ibm-modules/terraform-ibm-rag-sample-da/issues/235

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
