### PR TITLE
fix: use `default` secret group for storing GPG signing key

### DIFF
--- a/solutions/banking/main.tf
+++ b/solutions/banking/main.tf
@@ -12,7 +12,8 @@ locals {
   watson_ml_project_name           = try("${local.prefix}-${var.watson_project_name}", var.watson_project_name)
   sensitive_tokendata              = sensitive(data.ibm_iam_auth_token.tokendata.iam_access_token)
 
-  secret_group_id      = [for sg in data.ibm_sm_secret_groups.secret_groups.secret_groups : sg.id if sg.name == "default"][0]
+  sm_secret_group_name = "default"
+  secret_group_id      = [for sg in data.ibm_sm_secret_groups.secret_groups.secret_groups : sg.id if sg.name == local.sm_secret_group_name][0]
   generate_signing_key = var.create_secrets && (var.signing_key == null || var.signing_key == "")
 
   # Translate index name to lowercase to avoid Elastic errors
@@ -75,19 +76,20 @@ data "ibm_resource_instance" "secrets_manager_name" {
 
 # generate signing key if it is not provided.
 module "gpg_signing_key" {
-  count               = local.generate_signing_key ? 1 : 0
-  source              = "git::https://github.com/terraform-ibm-modules/terraform-ibm-devsecops-alm.git//prereqs?ref=v2.8.35"
-  ibmcloud_api_key    = var.ibmcloud_api_key
-  gpg_name            = var.gpg_name
-  gpg_email           = var.gpg_email
-  sm_resource_group   = var.secrets_manager_resource_group_name
-  sm_location         = var.secrets_manager_region
-  sm_instance_id      = var.secrets_manager_guid
-  sm_name             = data.ibm_resource_instance.secrets_manager_name[0].name
-  sm_endpoint_type    = var.secrets_manager_endpoint_type
-  sm_exists           = true
-  create_secret_group = true
-  create_signing_key  = true
+  count                = local.generate_signing_key ? 1 : 0
+  source               = "git::https://github.com/terraform-ibm-modules/terraform-ibm-devsecops-alm.git//prereqs?ref=v2.8.35"
+  ibmcloud_api_key     = var.ibmcloud_api_key
+  gpg_name             = var.gpg_name
+  gpg_email            = var.gpg_email
+  sm_resource_group    = var.secrets_manager_resource_group_name
+  sm_location          = var.secrets_manager_region
+  sm_instance_id       = var.secrets_manager_guid
+  sm_name              = data.ibm_resource_instance.secrets_manager_name[0].name
+  sm_endpoint_type     = var.secrets_manager_endpoint_type
+  sm_exists            = true
+  create_secret_group  = false
+  create_signing_key   = true
+  sm_secret_group_name = local.sm_secret_group_name
 }
 
 # secrets manager secrets - IBM signing key

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -31,7 +31,7 @@ const bankingSolutionsDir = "solutions/banking"
 var validRegions = []string{
 	"au-syd",
 	"jp-tok",
-	"eu-gb",
+	// "eu-gb", Commenting this region due to failure seen due to storage delegation, issue- https://github.ibm.com/GoldenEye/issues/issues/18116
 	"eu-de",
 	"us-south",
 }

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -31,7 +31,7 @@ const bankingSolutionsDir = "solutions/banking"
 var validRegions = []string{
 	"au-syd",
 	"jp-tok",
-	// "eu-gb", Commenting this region due to failure seen due to storage delegation, issue- https://github.ibm.com/GoldenEye/issues/issues/18116
+	// "eu-gb", Commenting this region due to failure seen due to storage delegation, issue- https://github.ibm.com/GoldenEye/issues/issues/17812
 	"eu-de",
 	"us-south",
 }


### PR DESCRIPTION
### Description

Fix to use `default` secret group for GPG signing key.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

 - `default` secret group will be used for storing GPG signing key

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
