### PR TITLE
fix: resolve Secrets Manager resource group mismatch in catalog onboarding

### DIFF
--- a/solutions/banking/main.tf
+++ b/solutions/banking/main.tf
@@ -135,22 +135,28 @@ data "ibm_resource_instance" "secrets_manager_name" {
   identifier = local.secrets_manager_guid
 }
 
+data "ibm_resource_group" "secrets_manager_resource_group" {
+  count = local.generate_signing_key ? 1 : 0
+  name  = var.secrets_manager_resource_group_name
+}
+
 # generate signing key if it is not provided.
 module "gpg_signing_key" {
-  count                = local.generate_signing_key ? 1 : 0
-  source               = "git::https://github.com/terraform-ibm-modules/terraform-ibm-devsecops-alm.git//prereqs?ref=v3.1.2"
-  ibmcloud_api_key     = var.ibmcloud_api_key
-  gpg_name             = var.gpg_name
-  gpg_email            = var.gpg_email
-  sm_resource_group    = var.secrets_manager_resource_group_name
-  sm_location          = local.secrets_manager_region
-  sm_instance_id       = local.secrets_manager_guid
-  sm_name              = data.ibm_resource_instance.secrets_manager_name[0].name
-  sm_endpoint_type     = var.secrets_manager_endpoint_type
-  sm_exists            = true
-  create_secret_group  = false
-  create_signing_key   = true
-  sm_secret_group_name = local.sm_secret_group_name
+  count                   = local.generate_signing_key ? 1 : 0
+  source                  = "git::https://github.com/terraform-ibm-modules/terraform-ibm-devsecops-alm.git//prereqs?ref=v3.1.2"
+  ibmcloud_api_key        = var.ibmcloud_api_key
+  gpg_name                = var.gpg_name
+  gpg_email               = var.gpg_email
+  sm_resource_group       = var.secrets_manager_resource_group_name
+  sm_resource_group_id    = data.ibm_resource_group.secrets_manager_resource_group[0].id
+  sm_location             = local.secrets_manager_region
+  sm_instance_id          = local.secrets_manager_guid
+  sm_name                 = data.ibm_resource_instance.secrets_manager_name[0].name
+  sm_endpoint_type        = var.secrets_manager_endpoint_type
+  sm_exists               = true
+  create_secret_group     = false
+  create_signing_key      = true
+  sm_secret_group_name    = local.sm_secret_group_name
 }
 
 # secrets manager secrets - IBM signing key

--- a/solutions/banking/main.tf
+++ b/solutions/banking/main.tf
@@ -135,28 +135,23 @@ data "ibm_resource_instance" "secrets_manager_name" {
   identifier = local.secrets_manager_guid
 }
 
-data "ibm_resource_group" "secrets_manager_resource_group" {
-  count = local.generate_signing_key ? 1 : 0
-  name  = var.secrets_manager_resource_group_name
-}
 
 # generate signing key if it is not provided.
 module "gpg_signing_key" {
-  count                   = local.generate_signing_key ? 1 : 0
-  source                  = "git::https://github.com/terraform-ibm-modules/terraform-ibm-devsecops-alm.git//prereqs?ref=v3.1.2"
-  ibmcloud_api_key        = var.ibmcloud_api_key
-  gpg_name                = var.gpg_name
-  gpg_email               = var.gpg_email
-  sm_resource_group       = var.secrets_manager_resource_group_name
-  sm_resource_group_id    = data.ibm_resource_group.secrets_manager_resource_group[0].id
-  sm_location             = local.secrets_manager_region
-  sm_instance_id          = local.secrets_manager_guid
-  sm_name                 = data.ibm_resource_instance.secrets_manager_name[0].name
-  sm_endpoint_type        = var.secrets_manager_endpoint_type
-  sm_exists               = true
-  create_secret_group     = false
-  create_signing_key      = true
-  sm_secret_group_name    = local.sm_secret_group_name
+  count                = local.generate_signing_key ? 1 : 0
+  source               = "git::https://github.com/terraform-ibm-modules/terraform-ibm-devsecops-alm.git//prereqs?ref=v3.1.2"
+  ibmcloud_api_key     = var.ibmcloud_api_key
+  gpg_name             = var.gpg_name
+  gpg_email            = var.gpg_email
+  sm_resource_group    = var.secrets_manager_resource_group_name
+  sm_location          = local.secrets_manager_region
+  sm_instance_id       = local.secrets_manager_guid
+  sm_name              = data.ibm_resource_instance.secrets_manager_name[0].name
+  sm_endpoint_type     = var.secrets_manager_endpoint_type
+  sm_exists            = true
+  create_secret_group  = false
+  create_signing_key   = true
+  sm_secret_group_name = local.sm_secret_group_name
 }
 
 # secrets manager secrets - IBM signing key

--- a/solutions/banking/variables.tf
+++ b/solutions/banking/variables.tf
@@ -81,7 +81,7 @@ variable "watsonx_assistant_instance_crn" {
 }
 
 variable "watson_discovery_instance_crn" {
-  description = "Cloud Resource Name (CRN) of the watsonx Discovery service instance. If provided, Discovery integration is enabled."
+  description = "Cloud Resource Name (CRN) of the Watson Discovery service instance. If provided, Discovery integration is enabled."
   type        = string
   default     = null
   validation {

--- a/tests/resources/existing-resources/outputs.tf
+++ b/tests/resources/existing-resources/outputs.tf
@@ -15,17 +15,17 @@ output "watsonx_assistant_region" {
 
 output "watson_discovery_instance_crn" {
   value       = ibm_resource_instance.discovery_instance.crn
-  description = "CRN of the watsonx Discovery instance"
+  description = "CRN of the Watson Discovery instance"
 }
 
 output "watson_discovery_instance_id" {
   value       = ibm_resource_instance.discovery_instance.guid
-  description = "GUID of the watsonx Discovery instance"
+  description = "GUID of the Watson Discovery instance"
 }
 
 output "watson_discovery_region" {
   value       = ibm_resource_instance.discovery_instance.location
-  description = "Region of the watsonx Discovery instance"
+  description = "Region of the Watson Discovery instance"
 }
 
 output "watsonx_machine_learning_instance_crn" {

--- a/tests/scripts/pre-validation.sh
+++ b/tests/scripts/pre-validation.sh
@@ -11,6 +11,7 @@ TERRAFORM_SOURCE_DIR="tests/resources/existing-resources"
 JSON_FILE="${DA_DIR}/catalogValidationValues.json"
 REGION="us-south"
 FILE_PATH="common-dev-assets/common-go-assets/common-permanent-resources.yaml"
+SECRETS_MANAGER_CRN=$(yq e '.secretsManagerCRN' "$FILE_PATH")
 SECRETS_MANAGER_RESOURCE_GROUP=$(yq e '.secretsManagerResourceGroup' "$FILE_PATH")
 PREFIX="rag-da-$(openssl rand -hex 2)"
 TF_VARS_FILE="terraform.tfvars"
@@ -50,7 +51,7 @@ TF_VARS_FILE="terraform.tfvars"
   watsonx_assistant_instance_crn_value=$(terraform output -state=terraform.tfstate -raw watsonx_assistant_instance_crn)
   watson_discovery_instance_crn_value=$(terraform output -state=terraform.tfstate -raw watson_discovery_instance_crn)
   watsonx_machine_learning_instance_crn_value=$(terraform output -state=terraform.tfstate -raw watsonx_machine_learning_instance_crn)
-  secrets_manager_instance_crn_value=$(terraform output -state=terraform.tfstate -raw secrets_manager_instance_crn)
+  secrets_manager_instance_crn_value="${SECRETS_MANAGER_CRN}"
   use_existing_resource_group_value=true
   create_continuous_delivery_service_instance_value=false
   trigger_ci_pipeline_run_value=false


### PR DESCRIPTION
### Description

Updated the pre-validation script to use the permanent Secrets Manager from common-dev-assets/common-go-assets/common-permanent-resources.yaml for catalog onboarding tests. Both the Secrets Manager CRN and resource group name are now read from the same configuration file, ensuring they point to the same instance.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

- Updated tests/scripts/pre-validation.sh to read Secrets Manager CRN and resource group from common-dev-assets/common-go-assets/common-permanent-resources.yaml

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
